### PR TITLE
fix 从docker内的nei使用volume中的数据时,路径不正确,应该是容器内的路径而不是外部路径

### DIFF
--- a/lib/nei/builder.js
+++ b/lib/nei/builder.js
@@ -705,6 +705,16 @@ class Builder extends EventEmitter {
         data.modelServer.path = data.modelServer.path.toString();
       }
     }
+    // 转换server.config.js中的绝对路径为相对路径
+    ['webRoot', 'viewRoot', 'mockViewRoot', 'mockApiRoot'].forEach(key => {
+      const absPath = data[key];
+      if (absPath && absPath.trim()) {
+        const relativePath = path.relative(process.cwd(), absPath);
+        data[key] = `path.resolve(__dirname,'../','${relativePath}')`
+      } else {
+        data[key] = `'${absPath || ''}'`;
+      }
+    })
     let content = Handlebars.compile(jtrConfigTpl)(data);
     this.output(neiServerConfigFilePath, content, true);
   }

--- a/lib/nei/template/server.config.js.tpl
+++ b/lib/nei/template/server.config.js.tpl
@@ -6,9 +6,9 @@
 var path = require('path');
 module.exports = {
     /* 根目录 */
-    webRoot: '{{webRoot}}',
+    webRoot: {{{webRoot}}},
     /* 视图目录 */
-    viewRoot: '{{viewRoot}}',
+    viewRoot: {{{viewRoot}}},
     /* 路由 */
     routes: {
         //"ALL /api/*": "代理所有接口, 这里输入代理服务器地址",
@@ -105,9 +105,9 @@ module.exports = {
     /* 项目的 key */
     projectKey: '{{projectKey}}',
     /* 同步模块mock数据路径 */
-    mockTpl: '{{mockViewRoot}}',
+    mockTpl: {{{mockViewRoot}}},
     /* 异步接口mock数据路径 */
-    mockApi: '{{mockApiRoot}}',
+    mockApi: {{{mockApiRoot}}},
     /* 是否修改代理的host */
     changeOrigin: true,
     /* 模板后缀 */


### PR DESCRIPTION
场景是这样的，
项目代码和nei的mock数据放在本地，然后通过数据卷volume的方式挂载到docker容器里，使用容器里的webpack和nei来作为运行时进行开发。
nei读取的server.config.js还是本地的文件，但是在docker里的路径已经是`/app/ftl-mock`了，所以希望这里能够在运行时才算出mock数据的绝对路径。